### PR TITLE
Generar guardar y listar canchas sin filtros

### DIFF
--- a/src/modules/Canchas/Application/CrearCancha.ts
+++ b/src/modules/Canchas/Application/CrearCancha.ts
@@ -1,0 +1,10 @@
+import { Cancha } from '../Domain/Cancha';
+import { CanchaRepository } from '../Domain/CanchaRepository';
+
+export class CrearCancha {
+    constructor(private readonly canchaRepository: CanchaRepository) {}
+
+    async ejecutar(datosCancha: Omit<Cancha, 'id'>): Promise<Cancha> {
+        return await this.canchaRepository.crear(datosCancha);
+    }
+}

--- a/src/modules/Canchas/Application/EditarCancha.ts
+++ b/src/modules/Canchas/Application/EditarCancha.ts
@@ -1,0 +1,10 @@
+import { Cancha } from '../Domain/Cancha';
+import { CanchaRepository } from '../Domain/CanchaRepository';
+
+export class EditarCancha {
+    constructor(private readonly canchaRepository: CanchaRepository) {}
+
+    async ejecutar(id: string, datosCancha: Partial<Cancha>): Promise<Cancha> {
+        return await this.canchaRepository.actualizar(id, datosCancha);
+    }
+}

--- a/src/modules/Canchas/Application/EliminarCancha.ts
+++ b/src/modules/Canchas/Application/EliminarCancha.ts
@@ -1,0 +1,9 @@
+import { CanchaRepository } from '../Domain/CanchaRepository';
+
+export class EliminarCancha {
+    constructor(private readonly canchaRepository: CanchaRepository) {}
+
+    async ejecutar(id: string): Promise<void> {
+        await this.canchaRepository.eliminar(id);
+    }
+}

--- a/src/modules/Canchas/Application/ListarCanchasPaginados.ts
+++ b/src/modules/Canchas/Application/ListarCanchasPaginados.ts
@@ -1,0 +1,12 @@
+import { Cancha } from '../Domain/Cancha';
+import { CanchaRepository } from '../Domain/CanchaRepository';
+import { PaginatedResponse } from '../../SharedKernel/Domain/PaginatedResponse';
+import { Criteria } from '../../SharedKernel/Domain/Criteria';
+
+export class ListarCanchasPaginados {
+    constructor(private readonly canchaRepository: CanchaRepository) {}
+
+    async ejecutar(criteria: Criteria): Promise<PaginatedResponse<Cancha>> {
+        return await this.canchaRepository.listarPaginado(criteria);
+    }
+}

--- a/src/modules/Canchas/Domain/Cancha.ts
+++ b/src/modules/Canchas/Domain/Cancha.ts
@@ -1,0 +1,9 @@
+export interface Cancha {
+    id: string;
+    nombre: string;
+    direccion: string;
+    capacidad: number;
+    tipoSuperficie: string;
+    precioHora: number;
+    disponible: boolean;
+}

--- a/src/modules/Canchas/Domain/CanchaRepository.ts
+++ b/src/modules/Canchas/Domain/CanchaRepository.ts
@@ -1,0 +1,11 @@
+import { Cancha } from './Cancha';
+import { PaginatedResponse } from '../../SharedKernel/Domain/PaginatedResponse';
+import { Criteria } from '../../SharedKernel/Domain/Criteria';
+
+export interface CanchaRepository {
+    crear(cancha: Omit<Cancha, 'id'>): Promise<Cancha>;
+    listarPaginado(criteria: Criteria): Promise<PaginatedResponse<Cancha>>;
+    obtenerPorId(id: string): Promise<Cancha | null>;
+    actualizar(id: string, cancha: Partial<Cancha>): Promise<Cancha>;
+    eliminar(id: string): Promise<void>;
+}

--- a/src/modules/Canchas/Infraestructure/CanchaApiRepository.ts
+++ b/src/modules/Canchas/Infraestructure/CanchaApiRepository.ts
@@ -1,0 +1,34 @@
+import { Cancha } from '../Domain/Cancha';
+import { CanchaRepository } from '../Domain/CanchaRepository';
+import { PaginatedResponse } from '../../SharedKernel/Domain/PaginatedResponse';
+import { Criteria } from '../../SharedKernel/Domain/Criteria';
+import { ApiRepository } from '../../SharedKernel/Infraestructure/ApiRepository';
+
+export class CanchaApiRepository extends ApiRepository implements CanchaRepository {
+    private readonly baseUrl = '/api/canchas';
+
+    async crear(cancha: Omit<Cancha, 'id'>): Promise<Cancha> {
+        return await this.post<Cancha>(this.baseUrl, cancha);
+    }
+
+    async listarPaginado(criteria: Criteria): Promise<PaginatedResponse<Cancha>> {
+        const queryParams = this.buildQueryParams(criteria);
+        return await this.get<PaginatedResponse<Cancha>>(`${this.baseUrl}?${queryParams}`);
+    }
+
+    async obtenerPorId(id: string): Promise<Cancha | null> {
+        try {
+            return await this.get<Cancha>(`${this.baseUrl}/${id}`);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async actualizar(id: string, cancha: Partial<Cancha>): Promise<Cancha> {
+        return await this.put<Cancha>(`${this.baseUrl}/${id}`, cancha);
+    }
+
+    async eliminar(id: string): Promise<void> {
+        await this.delete(`${this.baseUrl}/${id}`);
+    }
+}

--- a/src/modules/SharedKernel/Domain/Criteria.ts
+++ b/src/modules/SharedKernel/Domain/Criteria.ts
@@ -1,0 +1,18 @@
+export interface Filter {
+    field: string;
+    operator: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'like' | 'in' | 'not_in';
+    value: any;
+}
+
+export interface Sort {
+    field: string;
+    direction: 'asc' | 'desc';
+}
+
+export interface Criteria {
+    page?: number;
+    limit?: number;
+    filters?: Filter[];
+    sorts?: Sort[];
+    search?: string;
+}

--- a/src/modules/SharedKernel/Domain/PaginatedResponse.ts
+++ b/src/modules/SharedKernel/Domain/PaginatedResponse.ts
@@ -1,0 +1,9 @@
+export interface PaginatedResponse<T> {
+    data: T[];
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+}

--- a/src/modules/SharedKernel/Infraestructure/ApiRepository.ts
+++ b/src/modules/SharedKernel/Infraestructure/ApiRepository.ts
@@ -1,0 +1,87 @@
+import { Criteria } from '../Domain/Criteria';
+
+export abstract class ApiRepository {
+    protected readonly baseApiUrl: string;
+
+    constructor(baseApiUrl: string = '/api') {
+        this.baseApiUrl = baseApiUrl;
+    }
+
+    protected async get<T>(url: string): Promise<T> {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return await response.json();
+    }
+
+    protected async post<T>(url: string, data: any): Promise<T> {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return await response.json();
+    }
+
+    protected async put<T>(url: string, data: any): Promise<T> {
+        const response = await fetch(url, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return await response.json();
+    }
+
+    protected async delete(url: string): Promise<void> {
+        const response = await fetch(url, {
+            method: 'DELETE',
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+    }
+
+    protected buildQueryParams(criteria: Criteria): string {
+        const params = new URLSearchParams();
+
+        if (criteria.page) {
+            params.append('page', criteria.page.toString());
+        }
+
+        if (criteria.limit) {
+            params.append('limit', criteria.limit.toString());
+        }
+
+        if (criteria.search) {
+            params.append('search', criteria.search);
+        }
+
+        if (criteria.filters) {
+            criteria.filters.forEach((filter, index) => {
+                params.append(`filters[${index}][field]`, filter.field);
+                params.append(`filters[${index}][operator]`, filter.operator);
+                params.append(`filters[${index}][value]`, filter.value.toString());
+            });
+        }
+
+        if (criteria.sorts) {
+            criteria.sorts.forEach((sort, index) => {
+                params.append(`sorts[${index}][field]`, sort.field);
+                params.append(`sorts[${index}][direction]`, sort.direction);
+            });
+        }
+
+        return params.toString();
+    }
+}

--- a/src/sections/Canchas/CanchasContext.tsx
+++ b/src/sections/Canchas/CanchasContext.tsx
@@ -1,0 +1,130 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { Cancha } from '../../modules/Canchas/Domain/Cancha';
+import { PaginatedResponse } from '../../modules/SharedKernel/Domain/PaginatedResponse';
+import { Criteria } from '../../modules/SharedKernel/Domain/Criteria';
+import { CrearCancha } from '../../modules/Canchas/Application/CrearCancha';
+import { EditarCancha } from '../../modules/Canchas/Application/EditarCancha';
+import { EliminarCancha } from '../../modules/Canchas/Application/EliminarCancha';
+import { ListarCanchasPaginados } from '../../modules/Canchas/Application/ListarCanchasPaginados';
+import { CanchaApiRepository } from '../../modules/Canchas/Infraestructure/CanchaApiRepository';
+
+interface CanchasContextType {
+    canchas: PaginatedResponse<Cancha> | null;
+    loading: boolean;
+    error: string | null;
+    cargarCanchas: (criteria: Criteria) => Promise<void>;
+    crearCancha: (cancha: Omit<Cancha, 'id'>) => Promise<void>;
+    editarCancha: (id: string, cancha: Partial<Cancha>) => Promise<void>;
+    eliminarCancha: (id: string) => Promise<void>;
+}
+
+const CanchasContext = createContext<CanchasContextType | undefined>(undefined);
+
+// Configuración de dependencias
+const canchaRepository = new CanchaApiRepository();
+const crearCanchaUseCase = new CrearCancha(canchaRepository);
+const editarCanchaUseCase = new EditarCancha(canchaRepository);
+const eliminarCanchaUseCase = new EliminarCancha(canchaRepository);
+const listarCanchasUseCase = new ListarCanchasPaginados(canchaRepository);
+
+interface CanchasProviderProps {
+    children: ReactNode;
+}
+
+export function CanchasProvider({ children }: CanchasProviderProps) {
+    const [canchas, setCanchas] = useState<PaginatedResponse<Cancha> | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const cargarCanchas = useCallback(async (criteria: Criteria) => {
+        try {
+            setLoading(true);
+            setError(null);
+            const result = await listarCanchasUseCase.ejecutar(criteria);
+            setCanchas(result);
+        } catch (err) {
+            setError('Error al cargar las canchas');
+            console.error(err);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const crearCancha = useCallback(async (cancha: Omit<Cancha, 'id'>) => {
+        try {
+            setLoading(true);
+            setError(null);
+            await crearCanchaUseCase.ejecutar(cancha);
+            // Recargar la lista después de crear
+            if (canchas) {
+                await cargarCanchas({ page: 1, limit: canchas.limit });
+            }
+        } catch (err) {
+            setError('Error al crear la cancha');
+            console.error(err);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    }, [canchas, cargarCanchas]);
+
+    const editarCancha = useCallback(async (id: string, cancha: Partial<Cancha>) => {
+        try {
+            setLoading(true);
+            setError(null);
+            await editarCanchaUseCase.ejecutar(id, cancha);
+            // Recargar la lista después de editar
+            if (canchas) {
+                await cargarCanchas({ page: canchas.page, limit: canchas.limit });
+            }
+        } catch (err) {
+            setError('Error al editar la cancha');
+            console.error(err);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    }, [canchas, cargarCanchas]);
+
+    const eliminarCancha = useCallback(async (id: string) => {
+        try {
+            setLoading(true);
+            setError(null);
+            await eliminarCanchaUseCase.ejecutar(id);
+            // Recargar la lista después de eliminar
+            if (canchas) {
+                await cargarCanchas({ page: canchas.page, limit: canchas.limit });
+            }
+        } catch (err) {
+            setError('Error al eliminar la cancha');
+            console.error(err);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    }, [canchas, cargarCanchas]);
+
+    const value: CanchasContextType = {
+        canchas,
+        loading,
+        error,
+        cargarCanchas,
+        crearCancha,
+        editarCancha,
+        eliminarCancha,
+    };
+
+    return (
+        <CanchasContext.Provider value={value}>
+            {children}
+        </CanchasContext.Provider>
+    );
+}
+
+export function useCanchas() {
+    const context = useContext(CanchasContext);
+    if (context === undefined) {
+        throw new Error('useCanchas debe ser usado dentro de un CanchasProvider');
+    }
+    return context;
+}

--- a/src/sections/Canchas/CanchasList.tsx
+++ b/src/sections/Canchas/CanchasList.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useState } from 'react';
+import { useCanchas } from './CanchasContext';
+import { Cancha } from '../../modules/Canchas/Domain/Cancha';
+
+export default function CanchasList() {
+    const { canchas, loading, error, cargarCanchas, eliminarCancha } = useCanchas();
+    const [paginaActual, setPaginaActual] = useState(1);
+    const [canchaSeleccionada, setCanchaSeleccionada] = useState<Cancha | null>(null);
+    const [mostrarModalEliminar, setMostrarModalEliminar] = useState(false);
+
+    useEffect(() => {
+        cargarCanchas({ page: paginaActual, limit: 10 });
+    }, [cargarCanchas, paginaActual]);
+
+    const manejarEliminar = async () => {
+        if (canchaSeleccionada) {
+            try {
+                await eliminarCancha(canchaSeleccionada.id);
+                setMostrarModalEliminar(false);
+                setCanchaSeleccionada(null);
+            } catch (error) {
+                console.error('Error al eliminar cancha:', error);
+            }
+        }
+    };
+
+    const confirmarEliminar = (cancha: Cancha) => {
+        setCanchaSeleccionada(cancha);
+        setMostrarModalEliminar(true);
+    };
+
+    const cambiarPagina = (nuevaPagina: number) => {
+        setPaginaActual(nuevaPagina);
+    };
+
+    if (loading) {
+        return (
+            <div className="flex justify-center items-center h-64">
+                <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-500"></div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+                {error}
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex justify-between items-center">
+                <h2 className="text-2xl font-bold text-gray-900">Canchas</h2>
+                <button
+                    onClick={() => window.location.href = '/canchas/nueva'}
+                    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                >
+                    Nueva Cancha
+                </button>
+            </div>
+
+            {/* Tabla de canchas */}
+            <div className="bg-white shadow-md rounded-lg overflow-hidden">
+                <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                        <tr>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Nombre
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Dirección
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Capacidad
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Superficie
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Precio/Hora
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Estado
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Acciones
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                        {canchas?.data.map((cancha) => (
+                            <tr key={cancha.id} className="hover:bg-gray-50">
+                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                    {cancha.nombre}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                    {cancha.direccion}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                    {cancha.capacidad} personas
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                    {cancha.tipoSuperficie}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                    ${cancha.precioHora.toLocaleString()}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap">
+                                    <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                                        cancha.disponible 
+                                            ? 'bg-green-100 text-green-800' 
+                                            : 'bg-red-100 text-red-800'
+                                    }`}>
+                                        {cancha.disponible ? 'Disponible' : 'No disponible'}
+                                    </span>
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
+                                    <button
+                                        onClick={() => window.location.href = `/canchas/editar/${cancha.id}`}
+                                        className="text-blue-600 hover:text-blue-900"
+                                    >
+                                        Editar
+                                    </button>
+                                    <button
+                                        onClick={() => confirmarEliminar(cancha)}
+                                        className="text-red-600 hover:text-red-900"
+                                    >
+                                        Eliminar
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* Paginación */}
+            {canchas && canchas.totalPages > 1 && (
+                <div className="flex justify-center space-x-2">
+                    <button
+                        onClick={() => cambiarPagina(paginaActual - 1)}
+                        disabled={paginaActual === 1}
+                        className="px-3 py-2 text-sm bg-white border border-gray-300 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+                    >
+                        Anterior
+                    </button>
+                    
+                    {Array.from({ length: canchas.totalPages }, (_, i) => i + 1).map((pagina) => (
+                        <button
+                            key={pagina}
+                            onClick={() => cambiarPagina(pagina)}
+                            className={`px-3 py-2 text-sm rounded-md ${
+                                pagina === paginaActual
+                                    ? 'bg-blue-500 text-white'
+                                    : 'bg-white border border-gray-300 hover:bg-gray-50'
+                            }`}
+                        >
+                            {pagina}
+                        </button>
+                    ))}
+
+                    <button
+                        onClick={() => cambiarPagina(paginaActual + 1)}
+                        disabled={paginaActual === canchas.totalPages}
+                        className="px-3 py-2 text-sm bg-white border border-gray-300 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+                    >
+                        Siguiente
+                    </button>
+                </div>
+            )}
+
+            {/* Modal de confirmación de eliminación */}
+            {mostrarModalEliminar && (
+                <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+                    <div className="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+                        <div className="mt-3 text-center">
+                            <h3 className="text-lg leading-6 font-medium text-gray-900">
+                                Confirmar eliminación
+                            </h3>
+                            <div className="mt-2 px-7 py-3">
+                                <p className="text-sm text-gray-500">
+                                    ¿Estás seguro de que deseas eliminar la cancha "{canchaSeleccionada?.nombre}"?
+                                    Esta acción no se puede deshacer.
+                                </p>
+                            </div>
+                            <div className="items-center px-4 py-3 space-x-4">
+                                <button
+                                    onClick={() => setMostrarModalEliminar(false)}
+                                    className="px-4 py-2 bg-gray-500 text-white text-base font-medium rounded-md shadow-sm hover:bg-gray-700"
+                                >
+                                    Cancelar
+                                </button>
+                                <button
+                                    onClick={manejarEliminar}
+                                    className="px-4 py-2 bg-red-500 text-white text-base font-medium rounded-md shadow-sm hover:bg-red-700"
+                                >
+                                    Eliminar
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/sections/Canchas/CanchasSave.tsx
+++ b/src/sections/Canchas/CanchasSave.tsx
@@ -1,0 +1,275 @@
+import React, { useState, useEffect } from 'react';
+import { useCanchas } from './CanchasContext';
+import { Cancha } from '../../modules/Canchas/Domain/Cancha';
+
+interface CanchasSaveProps {
+    canchaId?: string;
+    onGuardar?: () => void;
+    onCancelar?: () => void;
+}
+
+export default function CanchasSave({ canchaId, onGuardar, onCancelar }: CanchasSaveProps) {
+    const { crearCancha, editarCancha, loading } = useCanchas();
+    const [formData, setFormData] = useState({
+        nombre: '',
+        direccion: '',
+        capacidad: 0,
+        tipoSuperficie: '',
+        precioHora: 0,
+        disponible: true,
+    });
+    const [errores, setErrores] = useState<{ [key: string]: string }>({});
+    const [guardando, setGuardando] = useState(false);
+
+    const esEdicion = Boolean(canchaId);
+
+    // Si es edición, cargar los datos de la cancha
+    useEffect(() => {
+        if (esEdicion && canchaId) {
+            // Aquí deberías cargar los datos de la cancha desde el contexto o API
+            // Por ahora lo dejo como placeholder
+            console.log('Cargar datos para edición:', canchaId);
+        }
+    }, [esEdicion, canchaId]);
+
+    const manejarCambio = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        const { name, value, type } = e.target;
+        
+        setFormData(prev => ({
+            ...prev,
+            [name]: type === 'number' ? Number(value) : 
+                    type === 'checkbox' ? (e.target as HTMLInputElement).checked :
+                    value
+        }));
+
+        // Limpiar error del campo si existe
+        if (errores[name]) {
+            setErrores(prev => ({ ...prev, [name]: '' }));
+        }
+    };
+
+    const validarFormulario = () => {
+        const nuevosErrores: { [key: string]: string } = {};
+
+        if (!formData.nombre.trim()) {
+            nuevosErrores.nombre = 'El nombre es requerido';
+        }
+
+        if (!formData.direccion.trim()) {
+            nuevosErrores.direccion = 'La dirección es requerida';
+        }
+
+        if (formData.capacidad <= 0) {
+            nuevosErrores.capacidad = 'La capacidad debe ser mayor a 0';
+        }
+
+        if (!formData.tipoSuperficie.trim()) {
+            nuevosErrores.tipoSuperficie = 'El tipo de superficie es requerido';
+        }
+
+        if (formData.precioHora <= 0) {
+            nuevosErrores.precioHora = 'El precio por hora debe ser mayor a 0';
+        }
+
+        setErrores(nuevosErrores);
+        return Object.keys(nuevosErrores).length === 0;
+    };
+
+    const manejarSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!validarFormulario()) {
+            return;
+        }
+
+        try {
+            setGuardando(true);
+
+            if (esEdicion && canchaId) {
+                await editarCancha(canchaId, formData);
+            } else {
+                await crearCancha(formData);
+            }
+
+            // Limpiar formulario después de crear
+            if (!esEdicion) {
+                setFormData({
+                    nombre: '',
+                    direccion: '',
+                    capacidad: 0,
+                    tipoSuperficie: '',
+                    precioHora: 0,
+                    disponible: true,
+                });
+            }
+
+            if (onGuardar) {
+                onGuardar();
+            }
+        } catch (error) {
+            console.error('Error al guardar cancha:', error);
+        } finally {
+            setGuardando(false);
+        }
+    };
+
+    return (
+        <div className="max-w-2xl mx-auto bg-white shadow-md rounded-lg overflow-hidden">
+            <div className="px-6 py-4 bg-gray-50 border-b">
+                <h2 className="text-xl font-semibold text-gray-800">
+                    {esEdicion ? 'Editar Cancha' : 'Nueva Cancha'}
+                </h2>
+            </div>
+
+            <form onSubmit={manejarSubmit} className="p-6 space-y-6">
+                {/* Nombre */}
+                <div>
+                    <label htmlFor="nombre" className="block text-sm font-medium text-gray-700 mb-2">
+                        Nombre *
+                    </label>
+                    <input
+                        type="text"
+                        id="nombre"
+                        name="nombre"
+                        value={formData.nombre}
+                        onChange={manejarCambio}
+                        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                            errores.nombre ? 'border-red-500' : 'border-gray-300'
+                        }`}
+                        placeholder="Ingrese el nombre de la cancha"
+                    />
+                    {errores.nombre && (
+                        <p className="mt-1 text-sm text-red-600">{errores.nombre}</p>
+                    )}
+                </div>
+
+                {/* Dirección */}
+                <div>
+                    <label htmlFor="direccion" className="block text-sm font-medium text-gray-700 mb-2">
+                        Dirección *
+                    </label>
+                    <input
+                        type="text"
+                        id="direccion"
+                        name="direccion"
+                        value={formData.direccion}
+                        onChange={manejarCambio}
+                        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                            errores.direccion ? 'border-red-500' : 'border-gray-300'
+                        }`}
+                        placeholder="Ingrese la dirección"
+                    />
+                    {errores.direccion && (
+                        <p className="mt-1 text-sm text-red-600">{errores.direccion}</p>
+                    )}
+                </div>
+
+                {/* Capacidad y Precio en una fila */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label htmlFor="capacidad" className="block text-sm font-medium text-gray-700 mb-2">
+                            Capacidad *
+                        </label>
+                        <input
+                            type="number"
+                            id="capacidad"
+                            name="capacidad"
+                            value={formData.capacidad}
+                            onChange={manejarCambio}
+                            min="1"
+                            className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                                errores.capacidad ? 'border-red-500' : 'border-gray-300'
+                            }`}
+                            placeholder="Número de personas"
+                        />
+                        {errores.capacidad && (
+                            <p className="mt-1 text-sm text-red-600">{errores.capacidad}</p>
+                        )}
+                    </div>
+
+                    <div>
+                        <label htmlFor="precioHora" className="block text-sm font-medium text-gray-700 mb-2">
+                            Precio por Hora *
+                        </label>
+                        <input
+                            type="number"
+                            id="precioHora"
+                            name="precioHora"
+                            value={formData.precioHora}
+                            onChange={manejarCambio}
+                            min="0"
+                            step="0.01"
+                            className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                                errores.precioHora ? 'border-red-500' : 'border-gray-300'
+                            }`}
+                            placeholder="0.00"
+                        />
+                        {errores.precioHora && (
+                            <p className="mt-1 text-sm text-red-600">{errores.precioHora}</p>
+                        )}
+                    </div>
+                </div>
+
+                {/* Tipo de Superficie */}
+                <div>
+                    <label htmlFor="tipoSuperficie" className="block text-sm font-medium text-gray-700 mb-2">
+                        Tipo de Superficie *
+                    </label>
+                    <select
+                        id="tipoSuperficie"
+                        name="tipoSuperficie"
+                        value={formData.tipoSuperficie}
+                        onChange={manejarCambio}
+                        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                            errores.tipoSuperficie ? 'border-red-500' : 'border-gray-300'
+                        }`}
+                    >
+                        <option value="">Seleccione el tipo de superficie</option>
+                        <option value="Césped natural">Césped natural</option>
+                        <option value="Césped sintético">Césped sintético</option>
+                        <option value="Concreto">Concreto</option>
+                        <option value="Parquet">Parquet</option>
+                        <option value="Arcilla">Arcilla</option>
+                        <option value="Tartán">Tartán</option>
+                    </select>
+                    {errores.tipoSuperficie && (
+                        <p className="mt-1 text-sm text-red-600">{errores.tipoSuperficie}</p>
+                    )}
+                </div>
+
+                {/* Disponibilidad */}
+                <div className="flex items-center">
+                    <input
+                        type="checkbox"
+                        id="disponible"
+                        name="disponible"
+                        checked={formData.disponible}
+                        onChange={manejarCambio}
+                        className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                    />
+                    <label htmlFor="disponible" className="ml-2 block text-sm text-gray-700">
+                        Cancha disponible para reservas
+                    </label>
+                </div>
+
+                {/* Botones */}
+                <div className="flex justify-end space-x-4 pt-6">
+                    <button
+                        type="button"
+                        onClick={onCancelar}
+                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 border border-gray-300 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={guardando || loading}
+                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        {guardando ? 'Guardando...' : esEdicion ? 'Actualizar' : 'Crear Cancha'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implementa el módulo completo de Canchas (CRUD y listado paginado) siguiendo la estructura de Jugadores, pero sin filtros en el listado.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
El usuario solicitó un módulo de gestión de canchas con funcionalidades de guardar y listar, similar al módulo de jugadores existente, pero con la especificación clave de que el listado de canchas no debía incluir filtros.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d4dd2d6-4fb8-46df-a0a0-756538802292">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d4dd2d6-4fb8-46df-a0a0-756538802292">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>